### PR TITLE
Fix for ModifyworldListener.canInteractWithMaterial

### DIFF
--- a/src/main/java/ru/tehkode/modifyworld/ModifyworldListener.java
+++ b/src/main/java/ru/tehkode/modifyworld/ModifyworldListener.java
@@ -109,7 +109,7 @@ public abstract class ModifyworldListener implements Listener {
     }
 
     protected boolean canInteractWithMaterial(Player player, String basePermission, Material type) {
-        return permissionsManager.has(player, basePermission + type.name().toLowerCase().replace("_", "")) && permissionsManager.has(player, basePermission + type.getId());
+        return permissionsManager.has(player, basePermission + type.name().toLowerCase().replace("_", "")) || permissionsManager.has(player, basePermission + type.getId());
     }
 
     private void registerEvents(Plugin plugin) {


### PR DESCRIPTION
canInteractWithMaterial was forcing checks for permissions for the material both by name and id, not OR.  Asked about this in the irc channel, and didn't get a response so I dove into the code.  Simple fix, but it was mucking up things quite a bit for me.
