### PR TITLE
Fixed ocelots explicitly. 

### DIFF
--- a/src/main/java/ru/tehkode/modifyworld/ModifyworldListener.java
+++ b/src/main/java/ru/tehkode/modifyworld/ModifyworldListener.java
@@ -78,7 +78,7 @@ public abstract class ModifyworldListener implements Listener {
 		} else if (entity instanceof Tameable) {
 			Tameable animal = (Tameable) entity;
 			
-			return "animal." + (entityName == "ozelot" ? "ocelot" : entityName) + (animal.isTamed() ? "." + ((Player) animal.getOwner()).getName() : "");
+			return "animal." + (entityName.equals("ozelot") ? "ocelot" : entityName) + (animal.isTamed() ? "." + ((Player) animal.getOwner()).getName() : "");
 		}
 
 		


### PR DESCRIPTION
Removed toString() reference.

_Regarding swedish 'ozelot':_
This is an internal minecraft bug. Bukkit refuses to fix the vast majority of these, and using their debug strings is not a good workaround.
