### PR TITLE
Attempt to fix fake-players being invincible through superperms.

### DIFF
--- a/src/main/java/ru/tehkode/modifyworld/handlers/EntityListener.java
+++ b/src/main/java/ru/tehkode/modifyworld/handlers/EntityListener.java
@@ -52,7 +52,7 @@ public class EntityListener extends ModifyworldListener {
 
 			if (edbe.getEntity() instanceof Player) {
 				player = (Player) edbe.getEntity();
-				if (edbe.getDamager() != null) { // Prevent from taking damage by entity
+				if (edbe.getDamager() != null && player.isOnline()) { // Prevent from taking damage by entity
 					if (_permissionDenied(player, "modifyworld.damage.take", edbe.getDamager())) {
 						cancelDamageEvent(player, event);
 					}


### PR DESCRIPTION
A Player entity that's not an actual player will always return false for permissions, making it invincible. isOnline() seems to be an adequate check to determine the difference between a real player and a fake.
