### PR TITLE
Fixes players being able to throw items if right-clicking blocks.

### DIFF
--- a/src/main/java/ru/tehkode/modifyworld/handlers/PlayerListener.java
+++ b/src/main/java/ru/tehkode/modifyworld/handlers/PlayerListener.java
@@ -251,7 +251,7 @@ public class PlayerListener extends ModifyworldListener {
 
 		Player player = event.getPlayer();
 
-		if (action == Action.RIGHT_CLICK_AIR) { //RIGHT_CLICK_AIR is cancelled by default.
+		if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) { //RIGHT_CLICK_AIR is cancelled by default.
 			switch (player.getItemInHand().getType()) {
 				case POTION: //Only check splash potions.
 					if ((player.getItemInHand().getDurability() & 0x4000) != 0x4000) {
@@ -267,7 +267,9 @@ public class PlayerListener extends ModifyworldListener {
 							event.getPlayer().updateInventory();
 						}
 					}
-					return;
+					if (action == Action.RIGHT_CLICK_AIR) {
+						return;
+					}
 			}
 		}
 


### PR DESCRIPTION
Prevents items being thrown when in range of blocks, but does not prevent switches, levers, etc. from being interacted with.

@t3hk0d3 I wrote the buggy throw code, what do I have to do to get this fix pulled? It's really _bugging_ me.
17f1ff384d101529cc894adcd52d00791e292d50

(Sorry that my rebasing attempts keep closing the pull requests.)
