### PR TITLE
! Fix using throwable / spawn egg on container (e.g. enderchest) can bypass `use` permission node check

### DIFF
--- a/src/main/java/ru/tehkode/modifyworld/handlers/PlayerListener.java
+++ b/src/main/java/ru/tehkode/modifyworld/handlers/PlayerListener.java
@@ -266,12 +266,12 @@ public class PlayerListener extends ModifyworldListener {
 							event.getPlayer().updateInventory();
 						}
 					}
-					return; // no need to check further
+					break; // NEED to check further
 				case MONSTER_EGG: // don't add MONSTER_EGGS here
 					if (permissionDenied(player, "modifyworld.spawn", ((SpawnEgg)player.getItemInHand().getData()).getSpawnedType())) {
 						event.setUseItemInHand(Result.DENY);
 					}
-					return; // no need to check further
+					break; // NEED to check further
 			}
 		}
 


### PR DESCRIPTION
Fixes #97 